### PR TITLE
fix: v1.8.3 - Support discovery of devices with non-connectable advertisements

### DIFF
--- a/custom_components/beurer_daylight_lamps/__init__.py
+++ b/custom_components/beurer_daylight_lamps/__init__.py
@@ -117,13 +117,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: BeurerConfigEntry) -> bo
 
     # Use Home Assistant's Bluetooth stack - this automatically uses all adapters
     # including ESPHome Bluetooth Proxies for better range and reliability
+    # Don't filter by connectable - some devices alternate between
+    # connectable and non-connectable advertisement packets
     ble_device = bluetooth.async_ble_device_from_address(
-        hass, mac_address, connectable=True
+        hass, mac_address
     )
 
     # Also get the latest service info for RSSI
     service_info = bluetooth.async_last_service_info(
-        hass, mac_address, connectable=True
+        hass, mac_address
     )
     rssi = service_info.rssi if service_info else None
 
@@ -210,8 +212,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: BeurerConfigEntry) -> bo
             instance.update_rssi(service_info.rssi)
 
         # Update the BLE device reference to use the best available adapter
+        # Don't filter by connectable - some devices alternate between
+        # connectable and non-connectable advertisement packets
         new_device = bluetooth.async_ble_device_from_address(
-            hass, mac_address, connectable=True
+            hass, mac_address
         )
         if new_device:
             instance.update_ble_device(new_device)
@@ -220,11 +224,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: BeurerConfigEntry) -> bo
         instance.mark_seen()
 
     # Register for advertisements from this specific device address
+    # Don't filter by connectable - some devices alternate between
+    # connectable and non-connectable advertisement packets
     entry.async_on_unload(
         bluetooth.async_register_callback(
             hass,
             _async_device_discovered,
-            {"address": mac_address, "connectable": True},
+            {"address": mac_address},
             BluetoothScanningMode.PASSIVE,
         )
     )
@@ -242,12 +248,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: BeurerConfigEntry) -> bo
         )
         instance.mark_unavailable()
 
+    # Don't filter by connectable - some devices alternate between
+    # connectable and non-connectable advertisement packets
     entry.async_on_unload(
         bluetooth.async_track_unavailable(
             hass,
             _async_device_unavailable,
             mac_address,
-            connectable=True,
         )
     )
     LOGGER.debug("Registered unavailability tracker for %s", mac_address)

--- a/custom_components/beurer_daylight_lamps/beurer_daylight_lamps.py
+++ b/custom_components/beurer_daylight_lamps/beurer_daylight_lamps.py
@@ -668,6 +668,8 @@ class BeurerInstance:
 
             # Use Home Assistant's Bluetooth stack to get fresh device reference
             # This uses all available adapters including ESPHome Bluetooth Proxies
+            # Don't filter by connectable - some devices alternate between
+            # connectable and non-connectable advertisement packets
             if self._hass:
                 from homeassistant.components import bluetooth
 
@@ -675,7 +677,7 @@ class BeurerInstance:
                     "Getting fresh device via HA Bluetooth stack for %s...", self._mac
                 )
                 fresh_device = bluetooth.async_ble_device_from_address(
-                    self._hass, self._mac, connectable=True
+                    self._hass, self._mac
                 )
                 if fresh_device:
                     LOGGER.debug(
@@ -687,7 +689,7 @@ class BeurerInstance:
 
                     # Get RSSI from service info
                     service_info = bluetooth.async_last_service_info(
-                        self._hass, self._mac, connectable=True
+                        self._hass, self._mac
                     )
                     if service_info and service_info.rssi:
                         self.update_rssi(service_info.rssi)

--- a/custom_components/beurer_daylight_lamps/config_flow.py
+++ b/custom_components/beurer_daylight_lamps/config_flow.py
@@ -313,11 +313,13 @@ class BeurerConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                 else:
                     # Use HA Bluetooth stack to find device (includes all proxies)
+                    # Don't filter by connectable - some devices alternate between
+                    # connectable and non-connectable advertisement packets
                     LOGGER.debug(
                         "Getting device %s via HA Bluetooth stack...", self._mac
                     )
                     ble_device = bluetooth.async_ble_device_from_address(
-                        self.hass, self._mac, connectable=True
+                        self.hass, self._mac
                     )
                     if not ble_device:
                         LOGGER.error(
@@ -327,7 +329,7 @@ class BeurerConfigFlow(ConfigFlow, domain=DOMAIN):
 
                     # Get RSSI from service info
                     service_info = bluetooth.async_last_service_info(
-                        self.hass, self._mac, connectable=True
+                        self.hass, self._mac
                     )
                     rssi = service_info.rssi if service_info else None
 

--- a/custom_components/beurer_daylight_lamps/manifest.json
+++ b/custom_components/beurer_daylight_lamps/manifest.json
@@ -3,24 +3,19 @@
     "name": "Beurer Daylight Therapy Lamps",
     "bluetooth": [
         {
-            "local_name": "TL100*",
-            "connectable": true
+            "local_name": "TL100*"
         },
         {
-            "local_name": "TL50*",
-            "connectable": true
+            "local_name": "TL50*"
         },
         {
-            "local_name": "TL70*",
-            "connectable": true
+            "local_name": "TL70*"
         },
         {
-            "local_name": "TL80*",
-            "connectable": true
+            "local_name": "TL80*"
         },
         {
-            "local_name": "TL90*",
-            "connectable": true
+            "local_name": "TL90*"
         }
     ],
     "codeowners": ["@moag1000"],
@@ -31,5 +26,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/moag1000/beurer_daylight_lamps/issues",
     "requirements": ["bleak-retry-connector>=3.0.0"],
-    "version": "1.8.2"
+    "version": "1.8.3"
 }


### PR DESCRIPTION
Some Beurer TL devices alternate between sending connectable and
non-connectable Bluetooth advertisement packets. Previously, the integration
only looked for connectable devices, causing intermittent discovery failures.

Changes:
- Removed connectable=True filters from all Bluetooth discovery APIs
- Updated manifest.json to accept both connectable and non-connectable advertisements
- Added comments explaining the behavior
- Bumped version to 1.8.3

This allows the integration to discover devices regardless of their current
advertisement type, while still requiring actual connectivity for setup and control.

Fixes issue where devices like TL100_F33D were visible in Bluetooth monitors
but not discovered by Home Assistant.